### PR TITLE
option to ignore mlang tags

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -52,7 +52,7 @@ class filter_fulltranslate extends moodle_text_filter {
         return $this->get_translation($text, $language, $format);
     }
 
-    private function containsmlangtags($text) {
+    protected function contains_multilang_tags($text) {
         $patternstocheck = [];
 
         $patternstocheck[] = '/{\s*mlang\s+(                               # Look for the leading {mlang
@@ -140,7 +140,7 @@ class filter_fulltranslate extends moodle_text_filter {
             return $text;
         }
 
-        if (!empty(get_config('filter_fulltranslate', 'skipmlangtags')) && $this->containsmlangtags($text)) {
+        if (!empty(get_config('filter_fulltranslate', 'skipmlangtags')) && $this->contains_multilang_tags($text)) {
             return $text;
         }
 

--- a/lang/en/filter_fulltranslate.php
+++ b/lang/en/filter_fulltranslate.php
@@ -31,5 +31,7 @@ $string['edittranslation'] = 'Edit translation';
 $string['filtername'] = 'Content translation filter';
 $string['showstringsinfooter'] = 'Show strings in footer';
 $string['showstringsinfooter_desc'] = 'Enable this if you want to see a list of strings that the filter translated on the page to be printed before the footer';
+$string['skipmlangtags'] = 'Skip text containing mlang tags';
+$string['skipmlangtags_desc'] = 'Enable this if you want to check text to be translated for mlang tags and skip auto generating a translation where they are found';
 $string['usegoogle'] = 'Use Google';
 $string['usegoogle_desc'] = 'Check this checkbox if you want the plugin to use the Google translate api, otherwise auto generated translations are same as original';

--- a/settings.php
+++ b/settings.php
@@ -23,4 +23,6 @@ if ($ADMIN->fulltree) {
         get_string('usegoogle_desc', 'filter_fulltranslate'), false));
     $settings->add(new admin_setting_configcheckbox('filter_fulltranslate/showstringsinfooter', get_string('showstringsinfooter', 'filter_fulltranslate'),
         get_string('showstringsinfooter_desc', 'filter_fulltranslate'), false));
+    $settings->add(new admin_setting_configcheckbox('filter_fulltranslate/skipmlangtags', get_string('skipmlangtags', 'filter_fulltranslate'),
+        get_string('skipmlangtags_desc', 'filter_fulltranslate'), false));
 }


### PR DESCRIPTION
Multi lang tags should take precedence over auto-translation. If the mlang filters run before this one then you end up with google mis-identifying the source language and re-translating the text again - e.g. mlang tags providing a Spanish translation that gets mis-identified as Catalan and re-translated badly.
This pr allows you to run mlang AFTER this filter.